### PR TITLE
Ignore na rows

### DIFF
--- a/R/match_us.R
+++ b/R/match_us.R
@@ -144,9 +144,10 @@ match_us <- function(x = data.frame(), matchbook = list(), from = 1, to = 2,
         byname <- names(matchbook[by])
 
         # Discard any rows that are completely missing ----------- 
-        norows <- apply(matchbook[names(matchbook) != byname],
+        norows <- apply(matchbook,
           MARGIN = 1,
-          FUN    = function(i) !all(is.na(i))
+          FUN    = function(i, b) !all(is.na(i[b])),
+          b      = c(from, to)
         )
         matchbook <- matchbook[norows, , drop = FALSE]
         

--- a/R/match_us.R
+++ b/R/match_us.R
@@ -61,9 +61,6 @@
 #'
 #' }
 #'
-#' 
-#' @note This function will only parse character and factor columns to protect
-#'   numeric and Date columns from conversion to character. 
 #'
 #' @return a data frame with re-defined data based on the dictionary 
 #'
@@ -144,7 +141,17 @@ match_us <- function(x = data.frame(), matchbook = list(), from = 1, to = 2,
     if (by_exists) {
       valid_by <- i_check_column_name(by, names(matchbook))
       if (valid_by) {
-        matchbook <- split(matchbook, matchbook[[by]])
+        byname <- names(matchbook[by])
+
+        # Discard any rows that are completely missing ----------- 
+        norows <- apply(matchbook[names(matchbook) != byname],
+          MARGIN = 1,
+          FUN    = function(i) !all(is.na(i))
+        )
+        matchbook <- matchbook[norows, , drop = FALSE]
+        
+        # Split the matchbook here -------------------------------
+        matchbook <- split(matchbook, matchbook[[byname]])
       } else {
         stop("`by` must be the name or position of a column in the dictionary")
       }

--- a/man/match_us.Rd
+++ b/man/match_us.Rd
@@ -86,10 +86,6 @@ all character/factor columns indiscriminantly, then setting
 
 }
 }
-\note{
-This function will only parse character and factor columns to protect
-numeric and Date columns from conversion to character.
-}
 \examples{
 
 # Read in dictionary and coded date examples --------------------

--- a/tests/testthat/test-match_us.R
+++ b/tests/testthat/test-match_us.R
@@ -65,13 +65,16 @@ test_that("definitions with missing from, to, and order will be ignored", {
   # Example: x column is specified
   mdf <- cbind(my_data_frame, x = 1:11, y = 1:11 > 5)
   cxn <- rbind(corrections, c(bad = NA, good = NA, column = "x", orders = NA))
+  cxn$junk <- sample(letters, 11)
+  cxn$more_junk <- runif(11)
+
   res <- match_us(mdf, cxn)
 
   expect_equal(res$x, 1:11)
   expect_equal(res$y, 1:11 > 5)
 
   # Example: y column is specified
-  cxn[nrow(cxn), 3] <- "y"
+  cxn[nrow(cxn), "column"] <- "y"
 
   res <- match_us(mdf, cxn)
 
@@ -79,7 +82,15 @@ test_that("definitions with missing from, to, and order will be ignored", {
   expect_equal(res$y, 1:11 > 5)
 
   # Example, missing data are entered into the "treatment" column
-  res <- match_us(mdf, rbind(cxn, data.frame(bad = NA, good = NA, column = "treatment", orders = NA)))
+  new_junk <- data.frame(
+    bad       = NA,
+    good      = NA,
+    column    = "treatment",
+    orders    = NA,
+    junk      = "what",
+    more_junk = pi
+  )
+  res <- match_us(mdf, rbind(cxn, new_junk))
 
   expect_equal(res$x, 1:11)
   expect_equal(res$y, 1:11 > 5)

--- a/tests/testthat/test-match_us.R
+++ b/tests/testthat/test-match_us.R
@@ -52,12 +52,39 @@ test_that("a list of data frames is needed for the second part", {
 test_that("columns can be specified for the data despite order", {
 
   expect_identical(match_us(my_data_frame, corrections[sample(4)],
-                                           from = "bad", 
-                                           to = "good",
-                                           by = "column"
-                                          ),
+                            from = "bad", 
+                            to = "good",
+                            by = "column"
+                           ),
                    cleaned_data)
             
+})
+
+test_that("definitions with missing from, to, and order will be ignored", {
+
+  # Example: x column is specified
+  mdf <- cbind(my_data_frame, x = 1:11, y = 1:11 > 5)
+  cxn <- rbind(corrections, c(bad = NA, good = NA, column = "x", orders = NA))
+  res <- match_us(mdf, cxn)
+
+  expect_equal(res$x, 1:11)
+  expect_equal(res$y, 1:11 > 5)
+
+  # Example: y column is specified
+  cxn[nrow(cxn), 3] <- "y"
+
+  res <- match_us(mdf, cxn)
+
+  expect_equal(res$x, 1:11)
+  expect_equal(res$y, 1:11 > 5)
+
+  # Example, missing data are entered into the "treatment" column
+  res <- match_us(mdf, rbind(cxn, data.frame(bad = NA, good = NA, column = "treatment", orders = NA)))
+
+  expect_equal(res$x, 1:11)
+  expect_equal(res$y, 1:11 > 5)
+  expect_equal(res$treatment, cleaned_data$treatment)
+
 })
 
 test_that("a single error will be thrown if the columns are not in the correct order", {


### PR DESCRIPTION
There was this thing in the R4EPIs project where we had to get the user to remove rows from the dictionary that had empty option codes (key/value pairs) because they were for numeric or logical or date columns or something like that. In any case, This discards any rows in the data frame that are missing both the from and to fields.